### PR TITLE
feature/employee can filter purchase list

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,11 +2,7 @@ class OrdersController < ApplicationController
   before_action :authenticate_employee!
 
   def index
-    @orders = if params['delivery_status'].nil?
-                current_employee.orders
-              else
-                current_employee.orders.filter_by_delivery_status(params[:delivery_status])
-              end
+    @orders = OrdersQuery.new(employee: current_employee, params: params).call
   end
 
   def create

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,7 +2,11 @@ class OrdersController < ApplicationController
   before_action :authenticate_employee!
 
   def index
-    @orders = current_employee.orders
+    @orders = if params['delivery_status'].nil?
+                current_employee.orders
+              else
+                current_employee.orders.filter_by_delivery_status(params[:delivery_status])
+              end
   end
 
   def create

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,4 +3,5 @@ class Order < ApplicationRecord
   belongs_to :reward
 
   enum delivery_status: { ordered: 'ordered', delivered: 'delivered' }
+  scope :filter_by_delivery_status, ->(delivery_status) { where delivery_status: delivery_status }
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,5 +3,4 @@ class Order < ApplicationRecord
   belongs_to :reward
 
   enum delivery_status: { ordered: 'ordered', delivered: 'delivered' }
-  scope :filter_by_delivery_status, ->(delivery_status) { where delivery_status: delivery_status }
 end

--- a/app/queries/orders_query.rb
+++ b/app/queries/orders_query.rb
@@ -17,7 +17,7 @@ class OrdersQuery
   end
 
   def filter_by_delivery_status
-    return if @params['delivery_status'].nil?
+    return unless @params['delivery_status']
 
     @scoped = @scoped.delivered if @params['delivery_status'] == 'delivered'
     @scoped = @scoped.ordered if @params['delivery_status'] == 'ordered'

--- a/app/queries/orders_query.rb
+++ b/app/queries/orders_query.rb
@@ -1,0 +1,25 @@
+class OrdersQuery
+  def initialize(employee:, params: {})
+    @params = params
+    @employee = employee
+  end
+
+  def call
+    initialize_colletions
+    filter_by_delivery_status
+    @scoped
+  end
+
+  private
+
+  def initialize_colletions
+    @scoped = @employee.orders
+  end
+
+  def filter_by_delivery_status
+    return if @params['delivery_status'].nil?
+
+    @scoped = @scoped.delivered if @params['delivery_status'] == 'delivered'
+    @scoped = @scoped.ordered if @params['delivery_status'] == 'ordered'
+  end
+end

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,5 +1,9 @@
 <h1>My bought rewards</h1>
 
+<td><%= link_to 'Delivered', orders_path(delivery_status: :delivered) %></td>
+<td><%= link_to 'Not delivered', orders_path(delivery_status: :ordered) %></td>
+<td><%= link_to 'All', orders_path %></td>
+
 <table class="table">
   <thead class="table-dark">
     <tr>
@@ -7,6 +11,7 @@
       <th>Description</th>
       <th>Purchase time</th>
       <th>Price</th>
+      <th>Status</th>
 
       <th colspan="3"></th>
     </tr>
@@ -19,6 +24,7 @@
         <td><%= order.reward.description %></td>
         <td><%= time_ago_in_words(order.created_at) %> ago</td>
         <td><%= order.purchase_price %></td>
+        <td><%= order.delivery_status %></td>
       </tr>
     <% end %>
   </tbody>

--- a/spec/features/order_filter_spec.rb
+++ b/spec/features/order_filter_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+# frozen_string_literal: true
+RSpec.describe 'Order filter spec', type: :feature do
+  let!(:employee) { create(:employee) }
+  let!(:admin) { create(:admin) }
+  let!(:order) { create(:order, employee: employee) }
+
+  before do
+    login_as employee, scope: :employee
+    visit rewards_path
+  end
+
+  it 'tests filtering orders' do
+    click_link 'My orders'
+    click_link 'Not delivered'
+    expect(page).to have_content order.reward.title
+    expect(page).to have_content order.reward.description
+    expect(page).to have_content order.purchase_price
+    expect(page).to have_content time_ago_in_words(order.created_at)
+
+    using_session('admin session') do
+      login_as admin, scope: :admin
+      visit admins_root_path
+      click_link 'Orders'
+      click_link 'Deliver'
+      expect(page).to have_content 'Order was successfully delivered.'
+    end
+
+    click_link 'Delivered'
+    expect(page).to have_content order.reward.title
+    expect(page).to have_content order.reward.description
+    expect(page).to have_content order.purchase_price
+    expect(page).to have_content time_ago_in_words(order.created_at)
+
+    click_link 'Not delivered'
+    expect(page).not_to have_content order.reward.title
+    expect(page).not_to have_content order.reward.description
+    expect(page).not_to have_content order.purchase_price
+    expect(page).not_to have_content time_ago_in_words(order.created_at)
+
+    click_link 'All'
+    expect(page).to have_content order.reward.title
+    expect(page).to have_content order.reward.description
+    expect(page).to have_content order.purchase_price
+    expect(page).to have_content time_ago_in_words(order.created_at)
+  end
+end

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -34,39 +34,5 @@ RSpec.describe 'Order spec', type: :feature do
     end
     click_link 'My orders'
     expect(page).to have_content '10'
-
-    # filtering bought rewards by employee
-    click_link 'My orders'
-    click_link 'Not delivered'
-    expect(page).to have_content reward.title
-    expect(page).to have_content reward.description
-    expect(page).to have_content Order.last.purchase_price
-    expect(page).to have_content time_ago_in_words(Order.last.created_at)
-
-    using_session('admin session') do
-      login_as admin, scope: :admin
-      visit admins_root_path
-      click_link 'Orders'
-      click_link 'Deliver'
-      expect(page).to have_content 'Order was successfully delivered.'
-    end
-
-    click_link 'Delivered'
-    expect(page).to have_content reward.title
-    expect(page).to have_content reward.description
-    expect(page).to have_content Order.last.purchase_price
-    expect(page).to have_content time_ago_in_words(Order.last.created_at)
-
-    click_link 'Not delivered'
-    expect(page).not_to have_content reward.title
-    expect(page).not_to have_content reward.description
-    expect(page).not_to have_content Order.last.purchase_price
-    expect(page).not_to have_content time_ago_in_words(Order.last.created_at)
-
-    click_link 'All'
-    expect(page).to have_content reward.title
-    expect(page).to have_content reward.description
-    expect(page).to have_content Order.last.purchase_price
-    expect(page).to have_content time_ago_in_words(Order.last.created_at)
   end
 end

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Order spec', type: :feature do
     expect(page).to have_content time_ago_in_words(Order.last.created_at)
 
     # checking if changing reward price does not affect the price in list of bought rewards
-    using_session('receiver session') do
+    using_session('admin session') do
       login_as admin, scope: :admin
       visit admins_rewards_path
       click_link 'Edit'
@@ -34,5 +34,39 @@ RSpec.describe 'Order spec', type: :feature do
     end
     click_link 'My orders'
     expect(page).to have_content '10'
+
+    # filtering bought rewards by employee
+    click_link 'My orders'
+    click_link 'Not delivered'
+    expect(page).to have_content reward.title
+    expect(page).to have_content reward.description
+    expect(page).to have_content Order.last.purchase_price
+    expect(page).to have_content time_ago_in_words(Order.last.created_at)
+
+    using_session('admin session') do
+      login_as admin, scope: :admin
+      visit admins_root_path
+      click_link 'Orders'
+      click_link 'Deliver'
+      expect(page).to have_content 'Order was successfully delivered.'
+    end
+
+    click_link 'Delivered'
+    expect(page).to have_content reward.title
+    expect(page).to have_content reward.description
+    expect(page).to have_content Order.last.purchase_price
+    expect(page).to have_content time_ago_in_words(Order.last.created_at)
+
+    click_link 'Not delivered'
+    expect(page).not_to have_content reward.title
+    expect(page).not_to have_content reward.description
+    expect(page).not_to have_content Order.last.purchase_price
+    expect(page).not_to have_content time_ago_in_words(Order.last.created_at)
+
+    click_link 'All'
+    expect(page).to have_content reward.title
+    expect(page).to have_content reward.description
+    expect(page).to have_content Order.last.purchase_price
+    expect(page).to have_content time_ago_in_words(Order.last.created_at)
   end
 end


### PR DESCRIPTION
Hi Nerds! 🤓

I added a new feature to our app:

1. Employees can click "Delivered", "Not delivered", and "All" links in the bought rewards list to filter their rewards.
2. Spec checks the option of filtering bought rewards for employees.

