### PR TITLE
feature/filter rewards by categories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,9 @@ RSpec/MultipleExpectations:
 RSpec/LetSetup:
   Enabled: false
 
+RSpec/DescribedClass:
+  Enabled: false
+
 Rails/LinkToBlank:
   Enabled: false
 

--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -2,7 +2,8 @@ class RewardsController < ApplicationController
   before_action :authenticate_employee!
 
   def index
-    @rewards = Reward.all.page params[:page]
+    @categories = Category.all
+    @rewards = RewardsQuery.new(categories: @categories, rewards: (Reward.all.page params[:page]), params: params).call.includes([:category])
   end
 
   def show

--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -3,10 +3,16 @@ class RewardsController < ApplicationController
 
   def index
     @categories = Category.all
-    @rewards = RewardsQuery.new(categories: @categories, rewards: (Reward.all.page params[:page]), params: params).call.includes([:category])
+    @rewards = RewardsQuery.new(filters: index_query_params).call.page params[:page]
   end
 
   def show
     @reward = Reward.find(params[:id])
   end
+end
+
+private
+
+def index_query_params
+  params.permit(:category)
 end

--- a/app/queries/rewards_query.rb
+++ b/app/queries/rewards_query.rb
@@ -1,0 +1,25 @@
+class RewardsQuery
+  def initialize(rewards:, categories:, params: {})
+    @params = params
+    @rewards = rewards
+    @categories = categories
+  end
+
+  def call
+    initialize_colletions
+    filter_by_categories
+    @scoped
+  end
+
+  private
+
+  def initialize_colletions
+    @scoped = @rewards
+  end
+
+  def filter_by_categories
+    return unless @params['category']
+
+    @scoped = @scoped.where(category: Category.find_by(title: @params['category']))
+  end
+end

--- a/app/queries/rewards_query.rb
+++ b/app/queries/rewards_query.rb
@@ -1,25 +1,21 @@
 class RewardsQuery
-  def initialize(rewards:, categories:, params: {})
-    @params = params
-    @rewards = rewards
-    @categories = categories
+  def initialize(filters: {})
+    @filters = filters
   end
 
   def call
-    initialize_colletions
+    initialize_collections
     filter_by_categories
     @scoped
   end
 
   private
 
-  def initialize_colletions
-    @scoped = @rewards
+  def initialize_collections
+    @scoped = Reward.all.includes([:category])
   end
 
   def filter_by_categories
-    return unless @params['category']
-
-    @scoped = @scoped.where(category: Category.find_by(title: @params['category']))
+    @scoped = @scoped.where(category_id: Category.find_by(title: @filters['category']).id) if @filters['category']
   end
 end

--- a/app/views/rewards/index.html.erb
+++ b/app/views/rewards/index.html.erb
@@ -1,26 +1,32 @@
 <h1>Rewards</h1>
 
-  <table class='table'>
-    <thead class="table-dark">
+<% @categories.each do |category| %>
+  <td><%= link_to category.title, rewards_path(category: category.title) %></td>
+<% end %>
+<td><%= link_to 'All', rewards_path %></td>
+
+<table class='table'>
+  <thead class="table-dark">
+    <tr>
+      <th>Title</th>
+      <th>Description</th>
+      <th>Price</th>
+      <th>Category</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @rewards.each do |reward| %>
       <tr>
-        <th>Title</th>
-        <th>Description</th>
-        <th>Price</th>
-        <th colspan="3"></th>
+        <td><%= reward.title %></td>
+        <td><%= reward.description %></td>
+        <td><%= number_to_currency(reward.price) %></td>
+        <td><%= reward.category.title %></td>
+        <td><%= link_to 'Show', reward %></td>
+        <td><%= link_to 'Buy', orders_path(reward: reward), method: :post, data: { confirm: 'Are you sure?' } %></td>
       </tr>
-    </thead>
-
-    <tbody>
-      <% @rewards.each do |reward| %>
-        <tr>
-          <td><%= reward.title %></td>
-          <td><%= reward.description %></td>
-          <td><%= number_to_currency(reward.price) %></td>
-          <td><%= link_to 'Show', reward %></td>
-          <td><%= link_to 'Buy', orders_path(reward: reward), method: :post, data: { confirm: 'Are you sure?' } %></td>
-        </tr>
-      <% end %>
-    </tbody>  
-  </table>
-      <%= paginate @rewards %>
-
+    <% end %>
+  </tbody>  
+</table>
+<%= paginate @rewards %>

--- a/app/views/rewards/index.html.erb
+++ b/app/views/rewards/index.html.erb
@@ -22,7 +22,11 @@
         <td><%= reward.title %></td>
         <td><%= reward.description %></td>
         <td><%= number_to_currency(reward.price) %></td>
-        <td><%= reward.category.title %></td>
+        <% if reward.category.present? %>
+          <td><%= reward.category.title %></td>
+        <% else %>
+          <td>(no category)</td>
+        <% end %>
         <td><%= link_to 'Show', reward %></td>
         <td><%= link_to 'Buy', orders_path(reward: reward), method: :post, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/spec/factories/rewards.rb
+++ b/spec/factories/rewards.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     sequence(:title) { |n| "factory bot reward title #{n}" }
     description { 'Reward - description' }
     price { rand(1..10) }
+    category { create :category }
   end
 end

--- a/spec/features/admin_category_spec.rb
+++ b/spec/features/admin_category_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 RSpec.describe 'Admin category spec', type: :feature do
   let!(:admin) { create(:admin) }
   let!(:category) { build(:category) }
-  let!(:reward) { create(:reward) }
+  let!(:reward) { create(:reward, category: nil) }
 
   before do
     login_as admin, scope: :admin

--- a/spec/features/reward_filter_spec.rb
+++ b/spec/features/reward_filter_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe 'Reward filter spec', type: :feature do
     click_link 'Rewards'
     click_link category1.title
     expect(page).to have_content reward1.title
-    expect(page).not_to have_content reward2.title
+    expect(page).to have_no_content reward2.title
 
     click_link category2.title
-    expect(page).not_to have_content reward1.title
+    expect(page).to have_no_content reward1.title
     expect(page).to have_content reward2.title
 
     click_link 'All'

--- a/spec/features/reward_filter_spec.rb
+++ b/spec/features/reward_filter_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+# frozen_string_literal: true
+RSpec.describe 'Reward filter spec', type: :feature do
+  let!(:employee) { create(:employee) }
+  let!(:category1) { create(:category, title: 'Category 1') }
+  let!(:category2) { create(:category, title: 'Category 2') }
+  let!(:reward1) { create(:reward, category: category1) }
+  let!(:reward2) { create(:reward, category: category2) }
+
+  before do
+    login_as employee, scope: :employee
+    visit root_path
+  end
+
+  it 'tests filtering rewards' do
+    click_link 'Rewards'
+    click_link category1.title
+    expect(page).to have_content reward1.title
+    expect(page).not_to have_content reward2.title
+
+    click_link category2.title
+    expect(page).not_to have_content reward1.title
+    expect(page).to have_content reward2.title
+
+    click_link 'All'
+    expect(page).to have_content reward1.title
+    expect(page).to have_content reward2.title
+  end
+end

--- a/spec/queries/rewards_query_spec.rb
+++ b/spec/queries/rewards_query_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe RewardsQuery do
+  before do
+    Bullet.enable = false
+  end
+
+  context 'with empty params' do
+    it 'filter' do
+      category1 = create(:category, title: 'Category 1')
+      category2 = create(:category, title: 'Category 2')
+      reward1 = create(:reward, category: category1)
+      reward2 = create(:reward, category: category2)
+      filter = {}
+
+      expect(RewardsQuery.new(filters: filter).call).to match_array([reward1, reward2])
+    end
+  end
+
+  context 'with Category1 params' do
+    it 'filter' do
+      category1 = create(:category, title: 'Category 1')
+      category2 = create(:category, title: 'Category 2')
+      reward1 = create(:reward, category: category1)
+      create(:reward, category: category2)
+      filter = { 'category' => category1.title }
+
+      expect(RewardsQuery.new(filters: filter).call).to match_array([reward1])
+    end
+  end
+
+  context 'with Category2 params' do
+    it 'filter' do
+      category1 = create(:category, title: 'Category 1')
+      category2 = create(:category, title: 'Category 2')
+      create(:reward, category: category1)
+      reward2 = create(:reward, category: category2)
+      filter = { 'category' => category2.title }
+
+      expect(RewardsQuery.new(filters: filter).call).to match_array([reward2])
+    end
+  end
+end


### PR DESCRIPTION
Hi Nerds! 🤓

According to the following AC, I have added new feature to our app:
 
- There's a link for each category on the rewards index
- Clicking on a category link filters rewards to the ones matching that category
- There's a system spec for an employee filtering rewards by a category

I added the rewards_query object, updated the rewards index view, and added a reward_filter spec. I had to update the rewards factory and admin_category_spec.