### PR TITLE
feature/add first and last name to employee model

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,9 @@ Rails/LinkToBlank:
 RSpec/ExampleLength:
   Enabled: false
 
+Rails/I18nLocaleTexts:
+  Enabled: false
+
 Naming/VariableNumber:
   Exclude:
     - 'spec/**/*_spec.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,9 +48,6 @@ Rails/LinkToBlank:
 RSpec/ExampleLength:
   Enabled: false
 
-Rails/I18nLocaleTexts:
-  Enabled: false
-
 Naming/VariableNumber:
   Exclude:
     - 'spec/**/*_spec.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development, :test do
   gem 'bullet'
   gem 'capybara', '~> 3.36'
   gem 'factory_bot_rails'
+  gem 'faker'
   gem 'rspec-rails', '~> 5.0.0'
   gem 'shoulda-matchers', '~> 5.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (2.23.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -326,6 +328,7 @@ DEPENDENCIES
   capybara (~> 3.36)
   devise (~> 4.8, >= 4.8.1)
   factory_bot_rails
+  faker
   kaminari (~> 1.2, >= 1.2.2)
   letter_opener (~> 1.4, >= 1.4.1)
   listen (~> 3.3)

--- a/app/controllers/admins/employees_controller.rb
+++ b/app/controllers/admins/employees_controller.rb
@@ -53,11 +53,11 @@ module Admins
     private
 
     def employee_params
-      params.require(:employee).permit(:email, :password, :number_of_available_kudos)
+      params.require(:employee).permit(:email, :password, :number_of_available_kudos, :first_name, :last_name)
     end
 
     def employee_params_without_password
-      params.require(:employee).permit(:email, :number_of_available_kudos)
+      params.require(:employee).permit(:email, :number_of_available_kudos, :first_name, :last_name)
     end
   end
 end

--- a/app/controllers/admins/rewards_controller.rb
+++ b/app/controllers/admins/rewards_controller.rb
@@ -40,11 +40,15 @@ module Admins
     end
 
     def import
-      file = params[:file]
-      import_service = ImportRewardsService.new(file)
-      return redirect_to import_admins_rewards_path, notice: import_service.errors.join(', ') unless import_service.call
+      if request.request_method == 'GET'
+        render :import_form
+      else
+        file = params[:file]
+        import_service = ImportRewardsService.new(file)
+        return redirect_to import_admins_rewards_path, notice: import_service.errors.join(', ') unless import_service.call
 
-      redirect_to admins_rewards_path, notice: 'Rewards imported!'
+        redirect_to admins_rewards_path, notice: 'Rewards imported!'
+      end
     end
 
     private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
   include Pundit::Authorization
 
   rescue_from Pundit::NotAuthorizedError, with: :employee_not_authorized
@@ -13,5 +15,12 @@ class ApplicationController < ActionController::Base
 
   def employee_not_authorized
     redirect_to root_path, notice: 'You are not authorized to perform this action.'
+  end
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[first_name last_name])
+    devise_parameter_sanitizer.permit(:account_update, keys: %i[first_name last_name])
   end
 end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -5,4 +5,10 @@ class Employee < ApplicationRecord
   has_many :given_kudos, class_name: 'Kudo', foreign_key: 'giver_id', dependent: :destroy, inverse_of: :giver
   has_many :received_kudos, class_name: 'Kudo', foreign_key: 'receiver_id', dependent: :destroy, inverse_of: :receiver
   has_many :orders, dependent: :destroy
+
+  validates :first_name, :last_name, presence: true
+
+  def full_name
+    [first_name, last_name].join(' ')
+  end
 end

--- a/app/views/admins/company_values/index.html.erb
+++ b/app/views/admins/company_values/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Company Values</h1>
-  <table>
-    <thead>
+  <table class='table'>
+    <thead class="table-dark">
       <tr>
         <th>Title</th>
         <th colspan="3"></th>

--- a/app/views/admins/employees/_form.html.erb
+++ b/app/views/admins/employees/_form.html.erb
@@ -12,19 +12,29 @@
   <% end %>
 
   <div class="field">
-    <%= form.label :email %>
+    <%= form.label :first_name %><br />
+    <%= form.text_field :first_name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :last_name %><br />
+    <%= form.text_field :last_name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :email %><br />
     <%= form.text_field :email %>
   </div>
 
   <div class="field">
-    <%= form.label :password %>
+    <%= form.label :password %><br />
     <%= form.text_field :password %>
   </div>
 
     <div class="field">
-    <%= form.label :number_of_available_kudos %>
+    <%= form.label :number_of_available_kudos %><br />
     <%= form.number_field :number_of_available_kudos %>
-  </div>
+  </div><br />
 
   <div class="actions">
     <%= form.submit %>

--- a/app/views/admins/employees/index.html.erb
+++ b/app/views/admins/employees/index.html.erb
@@ -7,9 +7,10 @@
 
 <h1>Employees</h1>
 
-  <table>
-    <thead>
+  <table class="table">
+    <thead class="table-dark">
       <tr>
+        <th>Full name</th>
         <th>Email</th>
         <th>Number of kudos</th>
         <th colspan="3"></th>
@@ -19,6 +20,7 @@
     <tbody>
       <% @employees.each do |employee| %>
         <tr employee-id="<%= employee.id %>">
+          <td><%= employee.full_name %></td>
           <td><%= employee.email %></td>
           <td><%= employee.number_of_available_kudos %></td>
           <td><%= link_to 'Show', admins_employee_path(employee) %></td>

--- a/app/views/admins/employees/show.html.erb
+++ b/app/views/admins/employees/show.html.erb
@@ -1,5 +1,7 @@
 <p>
   <h1>Employee information</h1>
+  <strong>Full name:</strong>
+    <%= @employee.full_name %></br>
   <strong>Email:</strong>
     <%= @employee.email %></br>
   <strong>Points:</strong>

--- a/app/views/admins/kudos/index.html.erb
+++ b/app/views/admins/kudos/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Kudos</h1>
 
-  <table>
-    <thead>
+  <table class='table'>
+    <thead class="table-dark">
       <tr>
         <th>Title</th>
         <th>Content</th>
@@ -16,8 +16,16 @@
         <tr>
           <td><%= kudo.title %></td>
           <td><%= kudo.content %></td>
-          <td><%= kudo.giver.email %></td>
-          <td><%= kudo.receiver.email %></td>
+          <% if kudo.giver.full_name.present? %>
+            <td><%= kudo.giver.full_name %></td>
+          <% else %>
+            <td><%= kudo.giver.email %></td>
+          <% end %>
+          <% if kudo.receiver.full_name.present? %>
+            <td><%= kudo.receiver.full_name %></td>
+          <% else %>
+            <td><%= kudo.receiver.email %></td>
+          <% end %>
           <td><%= link_to 'Destroy', admins_kudo_path(kudo), method: :delete, data: { confirm: 'Are you sure?' } %></td>
         </tr>
       <% end %>

--- a/app/views/admins/kudos/index.html.erb
+++ b/app/views/admins/kudos/index.html.erb
@@ -16,16 +16,8 @@
         <tr>
           <td><%= kudo.title %></td>
           <td><%= kudo.content %></td>
-          <% if kudo.giver.full_name.present? %>
-            <td><%= kudo.giver.full_name %></td>
-          <% else %>
-            <td><%= kudo.giver.email %></td>
-          <% end %>
-          <% if kudo.receiver.full_name.present? %>
-            <td><%= kudo.receiver.full_name %></td>
-          <% else %>
-            <td><%= kudo.receiver.email %></td>
-          <% end %>
+          <td><%= kudo.giver.full_name %></td>
+          <td><%= kudo.receiver.full_name %></td>
           <td><%= link_to 'Destroy', admins_kudo_path(kudo), method: :delete, data: { confirm: 'Are you sure?' } %></td>
         </tr>
       <% end %>

--- a/app/views/admins/orders/orders.csv.erb
+++ b/app/views/admins/orders/orders.csv.erb
@@ -1,4 +1,4 @@
-<%=raw CSV.generate_line(["Status", "Order ID", "Reward ID", "Reward title", "Reward description", "Order creation time", "Update time", "Purchase price", "Employee ID", "Employee email"]) -%>
+<%=raw CSV.generate_line(["Status", "Order ID", "Reward ID", "Reward title", "Reward description", "Order creation time", "Update time", "Purchase price", "Employee ID", "Employee full name", "Employee email"]) -%>
 <%- @orders.each do |order| -%>
   <%=raw CSV.generate_line([order.delivery_status, 
                             order.id, 
@@ -9,5 +9,6 @@
                             order.updated_at, 
                             order.purchase_price,
                             order.employee_id, 
+                            order.employee.full_name,
                             order.employee.email]) -%>
 <%- end -%>

--- a/app/views/admins/pages/_orders.html.erb
+++ b/app/views/admins/pages/_orders.html.erb
@@ -21,11 +21,7 @@
         <td><%= order.reward.description %></td>
         <td><%= time_ago_in_words(order.created_at) %> ago</td>
         <td><%= order.purchase_price %></td>
-        <% if order.employee.full_name.present? %>
-          <td><%= order.employee.full_name %></td>
-        <% else %>
-          <td><%= order.employee.email %></td>
-        <% end %>
+        <td><%= order.employee.full_name %></td>
         <td><%= link_to 'Deliver', deliver_admins_order_path(order), method: :patch, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>

--- a/app/views/admins/pages/_orders.html.erb
+++ b/app/views/admins/pages/_orders.html.erb
@@ -21,7 +21,11 @@
         <td><%= order.reward.description %></td>
         <td><%= time_ago_in_words(order.created_at) %> ago</td>
         <td><%= order.purchase_price %></td>
-        <td><%= order.employee.email %></td>
+        <% if order.employee.full_name.present? %>
+          <td><%= order.employee.full_name %></td>
+        <% else %>
+          <td><%= order.employee.email %></td>
+        <% end %>
         <td><%= link_to 'Deliver', deliver_admins_order_path(order), method: :patch, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,6 +4,16 @@
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
+    <%= f.label :first_name %><br />
+    <%= f.text_field :first_name, autocomplete: "first-name" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :last_name %><br />
+    <%= f.text_field :last_name, autocomplete: "last-name" %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,6 +4,16 @@
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
+    <%= f.label :first_name %><br />
+    <%= f.text_field :first_name, autofocus: true, autocomplete: "first-name" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :last_name %><br />
+    <%= f.text_field :last_name, autofocus: true, autocomplete: "last-name" %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>

--- a/app/views/kudos/index.html.erb
+++ b/app/views/kudos/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Kudos</h1>
 
-  <table>
-    <thead>
+  <table class='table'>
+    <thead class="table-dark">
       <tr>
         <th>Title</th>
         <th>Content</th>
@@ -18,8 +18,16 @@
         <tr>
           <td><%= kudo.title %></td>
           <td><%= kudo.content %></td>
-          <td><%= kudo.giver.email %></td>
-          <td><%= kudo.receiver.email %></td>
+          <% if kudo.giver.full_name.present? %>
+            <td><%= kudo.giver.full_name %></td>
+          <% else %>
+            <td><%= kudo.giver.email %></td>
+          <% end %>
+          <% if kudo.receiver.full_name.present? %>
+            <td><%= kudo.receiver.full_name %></td>
+          <% else %>
+            <td><%= kudo.receiver.email %></td>
+          <% end %>
           <td><%= kudo.company_value.title %></td>
           <td><%= link_to 'Show', kudo %></td>
           <% if current_employee == kudo.giver %>

--- a/app/views/kudos/index.html.erb
+++ b/app/views/kudos/index.html.erb
@@ -18,16 +18,8 @@
         <tr>
           <td><%= kudo.title %></td>
           <td><%= kudo.content %></td>
-          <% if kudo.giver.full_name.present? %>
-            <td><%= kudo.giver.full_name %></td>
-          <% else %>
-            <td><%= kudo.giver.email %></td>
-          <% end %>
-          <% if kudo.receiver.full_name.present? %>
-            <td><%= kudo.receiver.full_name %></td>
-          <% else %>
-            <td><%= kudo.receiver.email %></td>
-          <% end %>
+          <td><%= kudo.giver.full_name %></td>
+          <td><%= kudo.receiver.full_name %></td>
           <td><%= kudo.company_value.title %></td>
           <td><%= link_to 'Show', kudo %></td>
           <% if current_employee == kudo.giver %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,11 +1,9 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <!-- Required meta tags -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
 
     <title>Employee Recognition Platform</title>
@@ -31,15 +29,6 @@
       <%= yield %>
     </div>
     <p class="alert"><%= alert %></p>
-    <!-- Optional JavaScript; choose one of the two! -->
-
-    <!-- Option 1: Bootstrap Bundle with Popper -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
-
-    <!-- Option 2: Separate Popper and Bootstrap JS -->
-    <!--
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.10.2/dist/umd/popper.min.js" integrity="sha384-7+zCNj/IqJ95wo16oMtfsKbZ9ccEh31eOz1HGyDuCQ6wgnyJNSYdrPa03rtR1zdB" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.min.js" integrity="sha384-QJHtvGhmr9XOIpI6YVutG+2QOK9T+ZnN4kzFN1RtK3zEFEIsxhlmWl5/YESvpZ13" crossorigin="anonymous"></script>
-    -->
   </body>
 </html>

--- a/app/views/pages/_header.html.erb
+++ b/app/views/pages/_header.html.erb
@@ -1,12 +1,12 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-  <%= link_to "Employee Recognition Platform", root_path, class:"navbar-brand" %>
   <div class="container-fluid">
+    <%= link_to "Employee Recognition Platform", root_path, class:"navbar-brand" %>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
+
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-  
         <% if employee_signed_in? %>
             <li class="nav-item">
             <%= link_to "Sign Out", destroy_employee_session_path, method: :delete, class:"nav-link" %>
@@ -23,6 +23,7 @@
             <li class="nav-item">
               <%= link_to "My orders", orders_path, class:"nav-link" %>
             </li>
+
         <% else %>
             <li class="nav-item">
               <%= link_to "Sign Up", new_employee_registration_path, class:"nav-link" %>
@@ -30,6 +31,13 @@
             <li class="nav-item">
               <%= link_to "Sign In", new_employee_session_path, class:"nav-link" %>
             </li>
+        <% end %>
+      </ul>
+      <ul class="navbar-nav ml-auto mb-2 mb-lg-0">
+        <% if employee_signed_in? %>
+          <li class="nav-item">
+            <%=link_to "Account settings", edit_employee_registration_path, class:"nav-link" %>
+          </li>
         <% end %>
       </ul>
     </div>

--- a/app/views/pages/_header.html.erb
+++ b/app/views/pages/_header.html.erb
@@ -23,7 +23,6 @@
             <li class="nav-item">
               <%= link_to "My orders", orders_path, class:"nav-link" %>
             </li>
-
         <% else %>
             <li class="nav-item">
               <%= link_to "Sign Up", new_employee_registration_path, class:"nav-link" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     resources :company_values
     resources :rewards do
       collection do
-        get 'import', to: "rewards#import_form"
+        get 'import'
         post 'import'
       end
     end

--- a/db/migrate/20220915070627_add_first_name_and_last_name_to_employee.rb
+++ b/db/migrate/20220915070627_add_first_name_and_last_name_to_employee.rb
@@ -1,0 +1,8 @@
+class AddFirstNameAndLastNameToEmployee < ActiveRecord::Migration[6.1]
+  def change
+    add_column :employees, :first_name, :string, null: false, default: ""
+    add_column :employees, :last_name, :string, null: false, default: ""
+  end
+end
+
+

--- a/db/migrate/20220915070627_add_first_name_and_last_name_to_employee.rb
+++ b/db/migrate/20220915070627_add_first_name_and_last_name_to_employee.rb
@@ -4,5 +4,3 @@ class AddFirstNameAndLastNameToEmployee < ActiveRecord::Migration[6.1]
     add_column :employees, :last_name, :string, null: false, default: ""
   end
 end
-
-

--- a/db/migrate/20220917071553_remove_name_and_description_from_employees.rb
+++ b/db/migrate/20220917071553_remove_name_and_description_from_employees.rb
@@ -1,0 +1,6 @@
+class RemoveNameAndDescriptionFromEmployees < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :employees, :name
+    remove_column :employees, :description
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_08_130530) do
+ActiveRecord::Schema.define(version: 2022_09_17_071553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,10 +76,10 @@ ActiveRecord::Schema.define(version: 2022_09_08_130530) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "name"
-    t.text "description"
     t.integer "number_of_available_kudos", default: 10, null: false
     t.integer "number_of_available_points", default: 0, null: false
+    t.string "first_name", default: "", null: false
+    t.string "last_name", default: "", null: false
     t.index ["email"], name: "index_employees_on_email", unique: true
     t.index ["reset_password_token"], name: "index_employees_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 puts '# Creating Employees'
 5.times do |i|
-  employee = Employee.where(email: "email#{i+1}@test.com").first_or_create!(name: "Employee #{i}", description: "An employee.", password: "Password", number_of_available_points: 3)
+  employee = Employee.where(email: "email#{i+1}@test.com").first_or_create!(first_name: "First name #{i+1}", last_name: "Last name #{i+1}", password: "Password", number_of_available_points: 3)
   puts employee.email
 end
 

--- a/spec/factories/employees.rb
+++ b/spec/factories/employees.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :employee do
+    sequence(:first_name) { |n| "First name #{n}" }
+    sequence(:last_name) { |n| "Last name #{n}" }
     sequence(:email) { |n| "test#{n}@test.com" }
     password { 'test123' }
     number_of_available_kudos { 10 }

--- a/spec/factories/employees.rb
+++ b/spec/factories/employees.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :employee do
-    sequence(:first_name) { |n| "First name #{n}" }
-    sequence(:last_name) { |n| "Last name #{n}" }
-    sequence(:email) { |n| "test#{n}@test.com" }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    sequence(:email) { "#{first_name}.#{last_name}@test.com" }
     password { 'test123' }
     number_of_available_kudos { 10 }
     number_of_available_points { 0 }

--- a/spec/features/admin_employees_spec.rb
+++ b/spec/features/admin_employees_spec.rb
@@ -12,16 +12,21 @@ RSpec.describe 'Admin employees spec', type: :feature do
   it 'RUD employees by admin' do
     # listing employees by admin
     click_link 'Employees'
+    expect(page).to have_content employee.full_name
     expect(page).to have_content employee.email
     expect(page).to have_content employee.number_of_available_kudos
 
     # editing employees by admin
     click_link 'Edit'
     expect(page).to have_content 'Editing Employee'
+    fill_in 'employee[first_name]', with: 'New first name'
+    fill_in 'employee[last_name]', with: 'New last name'
     fill_in 'employee[email]', with: 'edited@test.pl'
     fill_in 'employee[password]', with: 'Passwordedited'
     click_button 'Update Employee'
     expect(page).to have_content 'Employee was successfully updated.'
+    expect(page).to have_content 'New first name'
+    expect(page).to have_content 'New last name'
     expect(page).to have_content 'edited@test.pl'
     expect(page).to have_content employee.number_of_available_kudos
 
@@ -39,5 +44,6 @@ RSpec.describe 'Admin employees spec', type: :feature do
     expect(page).to have_content 'Employee was successfully destroyed.'
     expect(page).not_to have_content employee.email
     expect(page).not_to have_content employee.number_of_available_kudos
+    expect(page).not_to have_content employee.full_name
   end
 end

--- a/spec/features/admin_exporting_orders_to_csv_spec.rb
+++ b/spec/features/admin_exporting_orders_to_csv_spec.rb
@@ -35,5 +35,7 @@ RSpec.describe 'Admin exporting order spec', type: :feature do
     expect(csv).to have_content order2.employee.id
     expect(csv).to have_content order1.employee.email
     expect(csv).to have_content order2.employee.email
+    expect(csv).to have_content order1.employee.full_name
+    expect(csv).to have_content order2.employee.full_name
   end
 end

--- a/spec/features/admin_order_spec.rb
+++ b/spec/features/admin_order_spec.rb
@@ -25,7 +25,13 @@ RSpec.describe 'Admin order spec', type: :feature do
 
   it 'tests admin delivering and order' do
     click_link 'Orders'
-    expect(page).to have_content order.employee.email
+
+    if order.employee.full_name.present?
+      expect(page).to have_content order.employee.full_name
+    else
+      expect(page).to have_content order.employee.email
+    end
+
     expect(page).to have_content order.reward.title
     expect(page).to have_content order.reward.description
     expect(page).to have_content time_ago_in_words(order.created_at)

--- a/spec/features/admin_order_spec.rb
+++ b/spec/features/admin_order_spec.rb
@@ -26,12 +26,7 @@ RSpec.describe 'Admin order spec', type: :feature do
   it 'tests admin delivering and order' do
     click_link 'Orders'
 
-    if order.employee.full_name.present?
-      expect(page).to have_content order.employee.full_name
-    else
-      expect(page).to have_content order.employee.email
-    end
-
+    expect(page).to have_content order.employee.full_name
     expect(page).to have_content order.reward.title
     expect(page).to have_content order.reward.description
     expect(page).to have_content time_ago_in_words(order.created_at)

--- a/spec/features/employee_spec.rb
+++ b/spec/features/employee_spec.rb
@@ -7,14 +7,17 @@ RSpec.describe 'Employee spec', type: :feature do
     # signing up by employees
     visit root_path
     click_link 'Sign Up'
+    fill_in 'employee[first_name]', with: employee.first_name
+    fill_in 'employee[last_name]', with: employee.last_name
     fill_in 'employee[email]', with: employee.email
     fill_in 'employee[password]', with: employee.password
     fill_in 'employee[password_confirmation]', with: employee.password
     click_button 'Sign up'
     expect(page).to have_content 'You have signed up successfully.'
 
-    # logging in by employees
+    # logging out and logging in by employees
     click_link 'Sign Out'
+    expect(page).to have_content 'You need to sign in or sign up before continuing.'
     fill_in 'employee[email]', with: employee.email
     fill_in 'employee[password]', with: employee.password
     click_button 'Log in'

--- a/spec/features/kudo_admin_spec.rb
+++ b/spec/features/kudo_admin_spec.rb
@@ -14,8 +14,18 @@ RSpec.describe 'Kudo spec', type: :feature do
     click_link 'Kudos'
     expect(page).to have_content kudo.title
     expect(page).to have_content kudo.content
-    expect(page).to have_content kudo.giver.email
-    expect(page).to have_content kudo.receiver.email
+
+    if kudo.giver.full_name.present?
+      expect(page).to have_content kudo.giver.full_name
+    else
+      expect(page).to have_content kudo.giver.email
+    end
+
+    if kudo.receiver.full_name.present?
+      expect(page).to have_content kudo.receiver.full_name
+    else
+      expect(page).to have_content kudo.receiver.email
+    end
 
     # destroying kudos by admin
     click_link 'Destroy'

--- a/spec/features/kudo_admin_spec.rb
+++ b/spec/features/kudo_admin_spec.rb
@@ -14,18 +14,8 @@ RSpec.describe 'Kudo spec', type: :feature do
     click_link 'Kudos'
     expect(page).to have_content kudo.title
     expect(page).to have_content kudo.content
-
-    if kudo.giver.full_name.present?
-      expect(page).to have_content kudo.giver.full_name
-    else
-      expect(page).to have_content kudo.giver.email
-    end
-
-    if kudo.receiver.full_name.present?
-      expect(page).to have_content kudo.receiver.full_name
-    else
-      expect(page).to have_content kudo.receiver.email
-    end
+    expect(page).to have_content kudo.giver.full_name
+    expect(page).to have_content kudo.receiver.full_name
 
     # destroying kudos by admin
     click_link 'Destroy'

--- a/spec/features/kudo_spec.rb
+++ b/spec/features/kudo_spec.rb
@@ -21,19 +21,8 @@ RSpec.describe 'Kudo spec', type: :feature do
     expect(page).to have_content 'Kudo was successfully created.'
     expect(page).to have_content kudo.title
     expect(page).to have_content kudo.content
-
-    if kudo.giver.full_name.present?
-      expect(page).to have_content kudo.giver.full_name
-    else
-      expect(page).to have_content kudo.giver.email
-    end
-
-    if kudo.receiver.full_name.present?
-      expect(page).to have_content kudo.receiver.full_name
-    else
-      expect(page).to have_content kudo.receiver.email
-    end
-
+    expect(page).to have_content kudo.giver.full_name
+    expect(page).to have_content kudo.receiver.full_name
     expect(page).to have_content company_value.title
 
     # editing and listing kudos by employees

--- a/spec/features/kudo_spec.rb
+++ b/spec/features/kudo_spec.rb
@@ -21,8 +21,19 @@ RSpec.describe 'Kudo spec', type: :feature do
     expect(page).to have_content 'Kudo was successfully created.'
     expect(page).to have_content kudo.title
     expect(page).to have_content kudo.content
-    expect(page).to have_content kudo.giver.email
-    expect(page).to have_content kudo.receiver.email
+
+    if kudo.giver.full_name.present?
+      expect(page).to have_content kudo.giver.full_name
+    else
+      expect(page).to have_content kudo.giver.email
+    end
+
+    if kudo.receiver.full_name.present?
+      expect(page).to have_content kudo.receiver.full_name
+    else
+      expect(page).to have_content kudo.receiver.email
+    end
+
     expect(page).to have_content company_value.title
 
     # editing and listing kudos by employees


### PR DESCRIPTION
Hi Nerds 🤓

I added a new feature. The employee model now has first_name and last_name. There are new fields in the registration form (first_name and last_name). Employees and admin can edit it.

AC:

- On the registration form there are two new fields: first_name and last_name
- An admin should be able to edit an employee's first & last name
- Existing employees should be able to edit their profile
- There is a presence validation set on first & last name
- There is NOT NULL constraint set on employee's first & last name

### Heroku review app:

**Employee:**
https://emp-kw-pr-29.herokuapp.com/
Login: [email1@test.com](mailto:email1@test.com)
Password: Password

**Admin:**
https://emp-kw-pr-29.herokuapp.com/admins/
Login: [admin@test.com](mailto:admin@test.com)
Password: Password1