### PR TITLE
feature/rewards delivery method

### DIFF
--- a/app/controllers/admins/rewards_controller.rb
+++ b/app/controllers/admins/rewards_controller.rb
@@ -54,7 +54,7 @@ module Admins
     private
 
     def reward_params
-      params.require(:reward).permit(:title, :description, :price, :category_id, :reward_photo)
+      params.require(:reward).permit(:title, :description, :price, :category_id, :reward_photo, :delivery_method)
     end
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -8,7 +8,7 @@ class OrdersController < ApplicationController
   def new
     @order = Order.new(reward: Reward.find(params[:reward]))
     @address = Address.find_or_initialize_by(employee: current_employee)
-    return unless current_employee.number_of_available_points < @order.reward.price
+    return render :new unless current_employee.number_of_available_points < @order.reward.price
 
     redirect_to rewards_path, notice: 'Your number of available points is less than price'
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,9 +5,18 @@ class OrdersController < ApplicationController
     @orders = OrdersQuery.new(employee: current_employee, params: params).call
   end
 
+  def new
+    @order = Order.new(reward: Reward.find(params[:reward]))
+    @address = Address.find_or_initialize_by(employee: current_employee)
+    return unless current_employee.number_of_available_points < @order.reward.price
+
+    redirect_to rewards_path, notice: 'Your number of available points is less than price'
+  end
+
   def create
     @order = Order.new
-    @reward = Reward.find(params[:reward])
+    @reward = Reward.find(order_params[:reward])
+    @address = Address.find_or_initialize_by(employee: current_employee)
     if current_employee.number_of_available_points < @reward.price
       redirect_to rewards_path, notice: 'Order was not created. Your number of available points is less than price'
     else
@@ -19,11 +28,22 @@ class OrdersController < ApplicationController
         ActiveRecord::Base.transaction do
           current_employee.save!
           @order.save!
+          @address.update!(address_params) if @reward.post?
         end
         redirect_to orders_url, notice: 'Order was successfully created.'
       rescue ActiveRecord::RecordInvalid => e
         render :new, notice: e.message, reward: @reward
       end
     end
+  end
+
+  private
+
+  def order_params
+    params.require(:order).permit(:reward)
+  end
+
+  def address_params
+    params.require(:address).permit(:street, :postcode, :city)
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,5 @@
+class Address < ApplicationRecord
+  belongs_to :employee
+
+  validates :street, :postcode, :city, presence: true
+end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -2,4 +2,5 @@ class Address < ApplicationRecord
   belongs_to :employee
 
   validates :street, :postcode, :city, presence: true
+  validates :postcode, format: { with: /[0-9]{2}-[0-9]{3}/, message: 'should be in the form 12-345' }
 end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -5,6 +5,7 @@ class Employee < ApplicationRecord
   has_many :given_kudos, class_name: 'Kudo', foreign_key: 'giver_id', dependent: :destroy, inverse_of: :giver
   has_many :received_kudos, class_name: 'Kudo', foreign_key: 'receiver_id', dependent: :destroy, inverse_of: :receiver
   has_many :orders, dependent: :destroy
+  has_one :address, dependent: :destroy
 
   validates :first_name, :last_name, presence: true
 

--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -9,4 +9,6 @@ class Reward < ApplicationRecord
   has_one_attached :reward_photo
 
   paginates_per 3
+
+  enum delivery_method: { online: 'online', post: 'post' }
 end

--- a/app/queries/orders_query.rb
+++ b/app/queries/orders_query.rb
@@ -13,7 +13,7 @@ class OrdersQuery
   private
 
   def initialize_colletions
-    @scoped = @employee.orders
+    @scoped = @employee.orders.includes(:reward)
   end
 
   def filter_by_delivery_status

--- a/app/views/admins/orders/orders.csv.erb
+++ b/app/views/admins/orders/orders.csv.erb
@@ -1,6 +1,7 @@
-<%=raw CSV.generate_line(["Status", "Order ID", "Reward ID", "Reward title", "Reward description", "Order creation time", "Update time", "Purchase price", "Employee ID", "Employee full name", "Employee email"]) -%>
+<%=raw CSV.generate_line(["Status", "Delivery method", "Order ID", "Reward ID", "Reward title", "Reward description", "Order creation time", "Update time", "Purchase price", "Employee ID", "Employee full name", "Employee email"]) -%>
 <%- @orders.each do |order| -%>
   <%=raw CSV.generate_line([order.delivery_status, 
+                            order.reward.delivery_method,
                             order.id, 
                             order.reward_id,
                             order.reward.title, 

--- a/app/views/admins/pages/_orders.html.erb
+++ b/app/views/admins/pages/_orders.html.erb
@@ -2,6 +2,7 @@
   <thead class="table-dark">
     <tr>
       <th>Status</th>
+      <th>Delivery method</th>
       <th>ID</th>
       <th>Title</th>
       <th>Description</th>
@@ -16,6 +17,7 @@
     <% orders.each do |order| %>
       <tr>
         <td><%= order.delivery_status %></td>
+        <td><%= order.reward.delivery_method %></td>
         <td><%= order.id %></td>
         <td><%= order.reward.title %></td>
         <td><%= order.reward.description %></td>

--- a/app/views/admins/rewards/_form.html.erb
+++ b/app/views/admins/rewards/_form.html.erb
@@ -12,26 +12,31 @@
   <% end %>
 
   <div class="field">
-    <%= form.label :title %>
+    <%= form.label :title %><br />
     <%= form.text_field :title %>
   </div>
 
   <div class="field">
-    <%= form.label :description %>
+    <%= form.label :description %><br />
     <%= form.text_area :description %>
   </div>
 
   <div class="field">
-    <%= form.label :category_id %>
+    <%= form.label :category_id %><br />
     <%= form.collection_select :category_id, Category.all, :id, :title, include_blank: "None" %>
   </div>
 
   <div class="field">
-    <%= form.label :price %>
-    <%= form.number_field :price, step: :any %>
+    <%= form.label :delivery_method %><br />
+    <%= form.select :delivery_method, Reward.delivery_methods.keys %>
   </div>
 
   <div class="field">
+    <%= form.label :price %><br />
+    <%= form.number_field :price, step: :any %>
+  </div>
+
+  <div class="field"><br />
     <%= form.label :reward_photo %>
     <%= form.file_field :reward_photo %>
   </div> 

--- a/app/views/admins/rewards/index.html.erb
+++ b/app/views/admins/rewards/index.html.erb
@@ -6,6 +6,7 @@
         <th>Description</th>
         <th>Price</th>
         <th>Category</th>
+        <th>Delivery method</th>
 
         <th colspan="3"></th>
       </tr>
@@ -21,6 +22,7 @@
           <% else %>
             <td>(no category)</td>
           <% end %>
+          <td><%= reward.delivery_method %></td>
           <td><%= link_to 'Show', admins_reward_path(reward) %></td>
           <td><%= link_to 'Edit', edit_admins_reward_path(reward) %></td>
           <td><%= link_to 'Destroy', admins_reward_path(reward), method: :delete, data: { confirm: 'Are you sure?' } %></td>         

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -11,6 +11,7 @@
       <th>Description</th>
       <th>Purchase time</th>
       <th>Price</th>
+      <th>Delivery method</th>
       <th>Status</th>
 
       <th colspan="3"></th>
@@ -24,6 +25,7 @@
         <td><%= order.reward.description %></td>
         <td><%= time_ago_in_words(order.created_at) %> ago</td>
         <td><%= order.purchase_price %></td>
+        <td><%= order.reward.delivery_method %></td>
         <td><%= order.delivery_status %></td>
       </tr>
     <% end %>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,0 +1,54 @@
+<h1>New Order</h1>
+
+<%= form_with(model: @order) do |form| %>
+  <% if @order.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@order.errors.count, "error") %> prohibited this order from being saved:</h2>
+
+      <ul>
+        <% @order.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% if @address.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@address.errors.count, "error") %> prohibited this address from being saved:</h2>
+
+      <ul>
+        <% @address.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.hidden_field :reward, value: @order.reward.id %>
+  </div>
+
+  <% if @order.reward.post?%>
+    <%= fields_for @address do |address_field| %>
+      <div class="field">  
+        <%= form.label :street %>
+        <%= address_field.text_field :street %>
+      </div>
+      <div class="field">  
+        <%= form.label :postcode %>
+        <%= address_field.text_field :postcode %>
+      </div>
+      <div class="field">  
+        <%= form.label :city %>
+        <%= address_field.text_field :city %>
+      </div>
+    <% end %>
+  <% end %>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>
+
+<%= link_to 'Back', rewards_path %>

--- a/app/views/rewards/index.html.erb
+++ b/app/views/rewards/index.html.erb
@@ -12,6 +12,7 @@
       <th>Description</th>
       <th>Price</th>
       <th>Category</th>
+      <th>Delivery method</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -27,8 +28,9 @@
         <% else %>
           <td>(no category)</td>
         <% end %>
+        <td><%= reward.delivery_method %></td>
         <td><%= link_to 'Show', reward %></td>
-        <td><%= link_to 'Buy', orders_path(reward: reward), method: :post, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Buy', new_order_path(reward: reward) %></td>
       </tr>
     <% end %>
   </tbody>  

--- a/app/views/rewards/show.html.erb
+++ b/app/views/rewards/show.html.erb
@@ -17,4 +17,6 @@
   <% end %>
 </p>
 
+<%= link_to 'Buy', new_order_path(reward: @reward) %>
+
 <%= link_to 'Back', rewards_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   
   resources :kudos
   resources :rewards, only: %i[index show]
-  resources :orders, only: %i[index create]
+  resources :orders, only: %i[index new create]
 
   root 'kudos#index'
 

--- a/db/migrate/20221005160841_add_delivery_method_to_reward.rb
+++ b/db/migrate/20221005160841_add_delivery_method_to_reward.rb
@@ -1,0 +1,5 @@
+class AddDeliveryMethodToReward < ActiveRecord::Migration[6.1]
+  def change
+    add_column :rewards, :delivery_method, :string
+  end
+end

--- a/db/migrate/20221005174131_create_addresses.rb
+++ b/db/migrate/20221005174131_create_addresses.rb
@@ -1,0 +1,12 @@
+class CreateAddresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :addresses do |t|
+      t.string :street
+      t.string :postcode
+      t.string :city
+      t.references :employee, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_17_071553) do
+ActiveRecord::Schema.define(version: 2022_10_05_174131) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,16 @@ ActiveRecord::Schema.define(version: 2022_09_17_071553) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "addresses", force: :cascade do |t|
+    t.string "street"
+    t.string "postcode"
+    t.string "city"
+    t.bigint "employee_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["employee_id"], name: "index_addresses_on_employee_id"
   end
 
   create_table "admins", force: :cascade do |t|
@@ -115,12 +125,14 @@ ActiveRecord::Schema.define(version: 2022_09_17_071553) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "category_id"
+    t.string "delivery_method"
     t.index ["category_id"], name: "index_rewards_on_category_id"
     t.index ["title"], name: "index_rewards_on_title", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "employees"
   add_foreign_key "kudos", "company_values"
   add_foreign_key "kudos", "employees", column: "giver_id"
   add_foreign_key "kudos", "employees", column: "receiver_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,7 @@ end
 
 puts '# Creating Rewards'
 5.times do |k|
-  reward = Reward.create(category_id: Category.all.sample.id, title: "Reward #{k+1}", description: "A reward.", price: k+1)
+  reward = Reward.create(category_id: Category.all.sample.id, title: "Reward #{k+1}", description: "A reward.", price: k+1, delivery_method: Reward.delivery_methods.values.sample)
   puts reward.title
 end
 

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -1,0 +1,6 @@
+namespace :migration do
+  desc 'Adds delivery method to existing rewards'
+  task add_delivery_method: :environment do
+    Reward.all.each { |reward| reward.update(delivery_method: 'online') }
+  end
+end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :address do
     street { Faker::Address.street_name }
-    postcode { Faker::Address.zip_code }
+    postcode { '11-111' }
     city { Faker::Address.city }
     employee
   end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :address do
+    street { Faker::Address.street_name }
+    postcode { Faker::Address.zip_code }
+    city { Faker::Address.city }
+    employee
+  end
+end

--- a/spec/factories/rewards.rb
+++ b/spec/factories/rewards.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     description { 'Reward - description' }
     price { rand(1..10) }
     category { create :category }
+    delivery_method { Reward.delivery_methods.values.sample }
   end
 end

--- a/spec/features/admin_exporting_orders_to_csv_spec.rb
+++ b/spec/features/admin_exporting_orders_to_csv_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe 'Admin exporting order spec', type: :feature do
     click_link 'Export'
 
     csv = CSV.parse(page.body)
-
     expect(csv).to have_content order1.delivery_status
     expect(csv).to have_content order2.delivery_status
+    expect(csv).to have_content order1.reward.delivery_method
+    expect(csv).to have_content order2.reward.delivery_method
     expect(csv).to have_content order1.id
     expect(csv).to have_content order2.id
     expect(csv).to have_content order1.reward.id

--- a/spec/features/admin_importing_rewards_from_csv_spec.rb
+++ b/spec/features/admin_importing_rewards_from_csv_spec.rb
@@ -38,7 +38,13 @@ RSpec.describe 'Admin importing rewards spec', type: :feature do
     # admin imports file with category that doesn't exist
     attach_file(file_fixture('import_rewards_test_category_doesnt_exist.csv'))
     click_button 'Import'
-    expect(page).to have_content "Category 5 doesn't exist"
+    expect(page).to have_content "Category: Category 5 doesn't exist"
+    expect(Reward.count).to eq 1
+
+    # admin imports file with delivery_method that doesn't exist
+    attach_file(file_fixture('import_rewards_test_delivery_method_doesnt_exist.csv'))
+    click_button 'Import'
+    expect(page).to have_content "Deliverty method: online1 doesn't exist"
     expect(Reward.count).to eq 1
 
     # admin imports correct file

--- a/spec/features/order_spec.rb
+++ b/spec/features/order_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 # frozen_string_literal: true
 RSpec.describe 'Order spec', type: :feature do
-  let!(:reward) { create(:reward, price: 10) }
-  let!(:employee) { create(:employee, number_of_available_points: 11) }
+  let!(:reward) { create(:reward, price: 10, delivery_method: 'post') }
+  let!(:reward2) { create(:reward, price: 1, delivery_method: 'online') }
+  let!(:address) { create(:address) }
+  let!(:employee) { create(:employee, number_of_available_points: 21, address: address) }
   let!(:admin) { create(:admin) }
 
   before do
@@ -11,23 +13,45 @@ RSpec.describe 'Order spec', type: :feature do
   end
 
   it 'tests orders' do
-    # showing a lower number of points after buying a reward
-    click_link 'Buy'
+    # showing a lower number of points after buying a reward with online delivery method
+    find(:xpath, "//tr[td[contains(.,'online')]]/td/a", text: 'Buy').click
+    click_button 'Create Order'
     expect(page).to have_content 'Order was successfully created'
-    expect(page).to have_content 'Your points: 1'
+    expect(page).to have_content 'Your points: 20'
+
+    # showing a lower number of points after buying a reward with post delivery method
+    click_link 'Rewards'
+    find(:xpath, "//tr[td[contains(.,'post')]]/td/a", text: 'Buy').click
+    fill_in 'address[street]', with: employee.address.street
+    fill_in 'address[postcode]', with: employee.address.postcode
+    fill_in 'address[city]', with: employee.address.city
+    click_button 'Create Order'
+    expect(page).to have_content 'Order was successfully created'
+    expect(page).to have_content 'Your points: 10'
+
+    # showing saved address for second purchase
+    click_link 'Rewards'
+    find(:xpath, "//tr[td[contains(.,'post')]]/td/a", text: 'Buy').click
+    expect(page).to have_field('address[street]', with: employee.address.street)
+    expect(page).to have_field('address[postcode]', with: employee.address.postcode)
+    expect(page).to have_field('address[city]', with: employee.address.city)
 
     # seeing bought rewards list by employees
     click_link 'My orders'
     expect(page).to have_content reward.title
+    expect(page).to have_content reward2.title
     expect(page).to have_content reward.description
-    expect(page).to have_content Order.last.purchase_price
-    expect(page).to have_content time_ago_in_words(Order.last.created_at)
+    expect(page).to have_content reward2.description
+    expect(page).to have_content Order.where(reward: reward).last.purchase_price
+    expect(page).to have_content Order.where(reward: reward2).last.purchase_price
+    expect(page).to have_content time_ago_in_words(Order.where(reward: reward).last.created_at)
+    expect(page).to have_content time_ago_in_words(Order.where(reward: reward2).last.created_at)
 
     # checking if changing reward price does not affect the price in list of bought rewards
     using_session('admin session') do
       login_as admin, scope: :admin
       visit admins_rewards_path
-      click_link 'Edit'
+      find(:xpath, "//tr[td[contains(.,'#{reward.title}')]]/td/a", text: 'Edit').click
       fill_in 'reward[price]', with: '8'
       click_button 'Update Reward'
       expect(page).to have_content 'Reward was successfully updated.'

--- a/spec/fixtures/files/import_rewards_test_category_doesnt_exist.csv
+++ b/spec/fixtures/files/import_rewards_test_category_doesnt_exist.csv
@@ -1,4 +1,4 @@
-Title,Description,Price,Category
-Reward 1,Description 1 updated,4,Category 5
-Reward 2,Description 2,2,Category 2
-Reward 3,Description 3,3,Category 3
+Title,Description,Price,Category,Delivery method
+Reward 1,Description 1 updated,4,Category 5,online
+Reward 2,Description 2,2,Category 2,post
+Reward 3,Description 3,3,Category 3,online

--- a/spec/fixtures/files/import_rewards_test_delivery_method_doesnt_exist.csv
+++ b/spec/fixtures/files/import_rewards_test_delivery_method_doesnt_exist.csv
@@ -1,4 +1,4 @@
 Title,Description,Price,Category,Delivery method
 Reward 1,Description 1 updated,4,Category 4,online
 Reward 2,Description 2,2,Category 2,post
-Reward 3,Description 3,3,Category 3,online
+Reward 3,Description 3,3,Category 3,online1

--- a/spec/fixtures/files/import_rewards_test_empty_title.csv
+++ b/spec/fixtures/files/import_rewards_test_empty_title.csv
@@ -1,4 +1,4 @@
-Title,Description,Price,Category
-,Description 1 updated,4,Category 4
-Reward 2,Description 2,2,Category 2
-Reward 3,Description 3,3,Category 3
+Title,Description,Price,Category, Delivery method
+,Description 1 updated,4,Category 4,online
+Reward 2,Description 2,2,Category 2,post
+Reward 3,Description 3,3,Category 3,online

--- a/spec/fixtures/files/import_rewards_test_with_duplicates.csv
+++ b/spec/fixtures/files/import_rewards_test_with_duplicates.csv
@@ -1,4 +1,4 @@
-Title,Description,Price,Category
-Reward 1,Description 1,1,Category 1
-Reward 1,Description 2,2,Category 2
-Reward 3,Description 3,3,Category 3
+Title,Description,Price,Category,Delivery method
+Reward 1,Description 1,1,Category 1,online
+Reward 1,Description 2,2,Category 2,post
+Reward 3,Description 3,3,Category 3,online


### PR DESCRIPTION
Hi Nerds 🤓

I added a new feature. Rewards has now delivery methods (online and post).

AC:

- A reward should have assigned a delivery method: `online`, or `post-delivery`
- When an employee chooses online - everything should stay as it's now
- When an employee chooses post-delivery he should be able to enter the delivery address - street, postcode, and city
- There is a presence validation set on the delivery address data
- An employee should see an error message once he skips one of the validated fields
- An admin can set the delivery method for each of the rewards
- Rewards import should be able to process the delivery method
- Once an employee sets his delivery address that address should be used for the next `post-delivery` order

### Heroku review app:

**Employee:**
https://emp-kw-pr-30.herokuapp.com/
Login: [email1@test.com](mailto:email1@test.com)
Password: Password

**Admin**:
https://emp-kw-pr-30.herokuapp.com/admins/
Login: [admin@test.com](mailto:admin@test.com)
Password: Password1